### PR TITLE
B162-removed listeners for queue when leaving screen. Also updated join queue flow

### DIFF
--- a/CranberryQueue/Map/MapViewController.swift
+++ b/CranberryQueue/Map/MapViewController.swift
@@ -168,22 +168,24 @@ class MapViewController: UIViewController, mapDelegate, UITextFieldDelegate, Log
         vc.playerController = playerController
         
         
-        if( self.queueId != nil && !isHost ){
-            self.db?.collection("contributor").document(self.queueId!).collection("members").document(self.uid).delete()
-        } else if( (self.queueId) != nil && isHost){
-            self.db?.collection("contributor").document(self.queueId!).delete()
-            
-            self.db?.collection("song").whereField("queueId", isEqualTo: queueId!).getDocuments(completion: { (snapshot, err) in
-                guard let snap = snapshot else {
-                    return
-                }
-                for doc in snap.documents {
-                    doc.reference.delete()
-                }
-            })
-            self.db?.collection("playlist").document(self.queueId!).delete()
-            self.db?.collection("playback").document(self.queueId!).delete()
-            self.db?.collection("location").document(self.queueId!).delete()
+        if(self.queueId != nil && self.queueId != vc.queueId){
+            if(!isHost){
+                self.db?.collection("contributor").document(self.queueId!).collection("members").document(self.uid).delete()
+            }else{
+                self.db?.collection("contributor").document(self.queueId!).delete()
+                
+                self.db?.collection("song").whereField("queueId", isEqualTo: self.queueId).getDocuments(completion: { (snapshot, err) in
+                    guard let snap = snapshot else {
+                        return
+                    }
+                    for doc in snap.documents {
+                        doc.reference.delete()
+                    }
+                })
+                self.db?.collection("playlist").document(self.queueId!).delete()
+                self.db?.collection("playback").document(self.queueId!).delete()
+                self.db?.collection("location").document(self.queueId!).delete()
+            }
         }
         
         self.db?.collection("contributor").document(data.queueId).collection("members").document(self.uid).setData([:

--- a/CranberryQueue/Queue/QueueViewController.swift
+++ b/CranberryQueue/Queue/QueueViewController.swift
@@ -87,6 +87,7 @@ class QueueViewController: UIViewController, searchDelegate, SongTableDelegate {
     
     override func viewWillDisappear(_ animated: Bool) {
         queueRef?.remove()
+        songTableView.songRef?.remove()
     }
     
     func updateNumSongs(_ numSongs: Int) {

--- a/CranberryQueue/Queue/QueueViewController.swift
+++ b/CranberryQueue/Queue/QueueViewController.swift
@@ -55,8 +55,6 @@ class QueueViewController: UIViewController, searchDelegate, SongTableDelegate {
     var db : Firestore? = nil
     
     var playerController: PlayerController?
-  
-    var queueRef: ListenerRegistration? = nil
     
     
     override func viewDidLoad() {

--- a/CranberryQueue/Queue/QueueViewController.swift
+++ b/CranberryQueue/Queue/QueueViewController.swift
@@ -47,6 +47,8 @@ class QueueViewController: UIViewController, searchDelegate, SongTableDelegate {
     
     weak var playerDelegate: QueuePlayerDelegate? = nil
     
+    var queueRef: ListenerRegistration? = nil
+    
     var db : Firestore? = nil
     
     
@@ -83,6 +85,10 @@ class QueueViewController: UIViewController, searchDelegate, SongTableDelegate {
         }
     }
     
+    override func viewWillDisappear(_ animated: Bool) {
+        queueRef?.remove()
+    }
+    
     func updateNumSongs(_ numSongs: Int) {
         DispatchQueue.main.async {
             self.numSongsLabel.text = String(numSongs)
@@ -92,7 +98,7 @@ class QueueViewController: UIViewController, searchDelegate, SongTableDelegate {
     func watchLocationDoc() {
         db = Firestore.firestore()
         
-        db?.collection("location").document(queueId!)
+        queueRef = db?.collection("location").document(queueId!)
             .addSnapshotListener({ (snapshot, error) in
                 
                 guard let snap = snapshot else {

--- a/CranberryQueue/Queue/SongTableView.swift
+++ b/CranberryQueue/Queue/SongTableView.swift
@@ -32,6 +32,8 @@ class SongTableView: UITableView, UITableViewDelegate, UITableViewDataSource, Qu
     
     weak var songDelegate: SongTableDelegate? = nil
     
+    var songRef: ListenerRegistration? = nil
+    
     var upvotes = [String]()
     var downvotes = [String]()
     var pendingUpvotes = [Song]()
@@ -41,7 +43,7 @@ class SongTableView: UITableView, UITableViewDelegate, UITableViewDataSource, Qu
     func watchPlaylist() {
         db = Firestore.firestore()
         
-        db?.collection("playlist").document(queueId!).collection("songs").order(by: "votes", descending: true).addSnapshotListener({ (snapshot, error) in
+        songRef = db?.collection("playlist").document(queueId!).collection("songs").order(by: "votes", descending: true).addSnapshotListener({ (snapshot, error) in
             self.songs = []
             guard let snap = snapshot else {
                 print(error!)

--- a/CranberryQueue/Shared/PlayerViewController.swift
+++ b/CranberryQueue/Shared/PlayerViewController.swift
@@ -243,6 +243,7 @@ class PlayerViewController: UIViewController, SPTAppRemotePlayerStateDelegate, m
     }
     
     func setupGuestListeners() {
+        //dont think we want to remove this ref ever
         db?.collection("playback").document(queueId!).addSnapshotListener({ (snapshot, error) in
             if let err = error {
                 print(err)


### PR DESCRIPTION
Previously if the queue would delete if the user was previously the host of a queue but i forgot to check whether or not he was rejoining the same queue before deleting it.  The fix to this bug is also in this pr. Should have probably made another ticket for this