### PR TITLE
F296

### DIFF
--- a/CranberryQueue/AppDelegate.swift
+++ b/CranberryQueue/AppDelegate.swift
@@ -39,7 +39,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, SPTSessionManagerDelegate
             let tokenRefreshURL = URL(string: "https://cranberryqueue.herokuapp.com/api/refresh_token") {
             self.configuration.tokenSwapURL = tokenSwapURL
             self.configuration.tokenRefreshURL = tokenRefreshURL
-            self.configuration.playURI = ""
+            self.configuration.playURI = nil
         }
         let manager = SPTSessionManager(configuration: self.configuration, delegate: self)
         return manager

--- a/CranberryQueue/AppDelegate.swift
+++ b/CranberryQueue/AppDelegate.swift
@@ -24,6 +24,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, SPTSessionManagerDelegate
     
     weak var appPlayerDelegate: RemoteDelegate?
     weak var appMapDelegate: RemoteDelegate?
+    weak var appQueueDelegate: RemoteDelegate?
     weak var seshDelegate: SessionDelegate?
     
     let SpotifyClientID = "02294b5911c543599eb7fb37d1ed2d39"
@@ -98,6 +99,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, SPTSessionManagerDelegate
     
     func appRemoteDidEstablishConnection(_ appRemote: SPTAppRemote) {
         print("connected")
+        appQueueDelegate?.updateConnectionStatus(connected: true)
         appPlayerDelegate?.updateConnectionStatus(connected: true)
         appMapDelegate?.updateConnectionStatus(connected: true)
     }
@@ -109,6 +111,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, SPTSessionManagerDelegate
     func appRemote(_ appRemote: SPTAppRemote, didFailConnectionAttemptWithError error: Error?) {
         print("failed")
         /// player controller does not need to be notified of failure
+        appQueueDelegate?.updateConnectionStatus(connected: false)
         appMapDelegate?.updateConnectionStatus(connected: false)
     }
     

--- a/CranberryQueue/Base.lproj/Main.storyboard
+++ b/CranberryQueue/Base.lproj/Main.storyboard
@@ -522,8 +522,8 @@
                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="searchIcon" translatesAutoresizingMaskIntoConstraints="NO" id="c0c-J5-2qe">
-                                <rect key="frame" x="316" y="166.66666666666666" width="28" height="28"/>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="plus" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="c0c-J5-2qe">
+                                <rect key="frame" x="316" y="169" width="28" height="24.000000000000014"/>
                                 <color key="tintColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="28" id="Gws-hZ-jha"/>
@@ -573,7 +573,7 @@
                         <outlet property="numMembersLabel" destination="rlb-aE-c6W" id="69g-Cl-boB"/>
                         <outlet property="numSongsLabel" destination="1By-Ce-MQF" id="1Ww-Am-68V"/>
                         <outlet property="playerView" destination="mRc-5P-hj1" id="e8Z-N8-3TO"/>
-                        <outlet property="searchIconImageView" destination="c0c-J5-2qe" id="FdD-tT-slW"/>
+                        <outlet property="plusIconImageView" destination="c0c-J5-2qe" id="57a-kw-mt5"/>
                         <outlet property="segmentedContainerView" destination="wSF-8f-4OK" id="cMj-wP-YJw"/>
                         <outlet property="songTableView" destination="ZLZ-9b-5m8" id="3w7-Kq-bAT"/>
                     </connections>

--- a/CranberryQueue/Map/MapViewController.swift
+++ b/CranberryQueue/Map/MapViewController.swift
@@ -347,7 +347,6 @@ class MapViewController: UIViewController, UITextFieldDelegate, MapControllerDel
             /// close the join queue modal
             closeJoinForm()
         }
-
         return true
     }
     
@@ -402,6 +401,7 @@ class MapViewController: UIViewController, UITextFieldDelegate, MapControllerDel
     
     // Create queue from add icon
     func createPublicQueue(withName name: String) {
+        self.isCreating = false
         guard let coords = self.controllerMapDelegate?.getCoords() else { return }
         self.controllerMapDelegate?.getGeoCode(withLocation: coords, completion: { (city, region) in
             var ref : DocumentReference? = nil

--- a/CranberryQueue/Map/MapViewController.swift
+++ b/CranberryQueue/Map/MapViewController.swift
@@ -380,6 +380,12 @@ class MapViewController: UIViewController, UITextFieldDelegate, MapControllerDel
     @objc func joinPublicQueue() {
         let data = queueDetailModal.currentQueue!
         self.getIsUserHostOf(queueId: data.queueId) { (isHost) in
+            if isHost {
+                if !((UIApplication.shared.delegate as? AppDelegate)?.appRemote.isConnected)! {
+                    self.showAppRemoteAlert()
+                    return
+                }
+            }
             self.presentQueueScreen(queueId: data.queueId, name: data.name, code: nil, isHost: isHost)
         }
     }
@@ -394,7 +400,13 @@ class MapViewController: UIViewController, UITextFieldDelegate, MapControllerDel
            if snap.documents.count == 0 { return }
            let id = snap.documents[0].documentID
            self.getIsUserHostOf(queueId: id) { (isHost) in
-               self.presentQueueScreen(queueId: id, name: "", code: code, isHost: isHost)
+            if isHost {
+                if !((UIApplication.shared.delegate as? AppDelegate)?.appRemote.isConnected)! {
+                    self.showAppRemoteAlert()
+                    return
+                }
+            }
+            self.presentQueueScreen(queueId: id, name: "", code: code, isHost: isHost)
            }
        })
     }

--- a/CranberryQueue/Map/MapViewController.swift
+++ b/CranberryQueue/Map/MapViewController.swift
@@ -386,19 +386,19 @@ class MapViewController: UIViewController, UITextFieldDelegate, MapControllerDel
     }
 
     // Join queue from search icon
-       func joinPrivateQueue(code: String) {
-           db?.collection("location").whereField("code", isEqualTo: code).getDocuments(completion: { (snapshot, error) in
-               guard let snap = snapshot else {
-                   print(error!)
-                   return
-               }
-               if snap.documents.count == 0 { return }
-               let id = snap.documents[0].documentID
-               self.getIsUserHostOf(queueId: id) { (isHost) in
-                   self.presentQueueScreen(queueId: id, name: "", code: code, isHost: isHost)
-               }
-           })
-       }
+    func joinPrivateQueue(code: String) {
+       db?.collection("location").whereField("code", isEqualTo: code).getDocuments(completion: { (snapshot, error) in
+           guard let snap = snapshot else {
+               print(error!)
+               return
+           }
+           if snap.documents.count == 0 { return }
+           let id = snap.documents[0].documentID
+           self.getIsUserHostOf(queueId: id) { (isHost) in
+               self.presentQueueScreen(queueId: id, name: "", code: code, isHost: isHost)
+           }
+       })
+    }
     
     // Create queue from add icon
     func createPublicQueue(withName name: String) {

--- a/CranberryQueue/Queue/QueueViewController.swift
+++ b/CranberryQueue/Queue/QueueViewController.swift
@@ -30,7 +30,8 @@ class QueueViewController: UIViewController, SegmentedJointDelegate, SongTableDe
     
     @IBOutlet weak var leaveQueueImageView: UIImageView!
     @IBOutlet var songTableView: SongTableView!
-    @IBOutlet var searchIconImageView: UIImageView!
+    
+    @IBOutlet weak var plusIconImageView: UIImageView!
     @IBOutlet var nameLabel: UILabel!
     @IBOutlet var numMembersLabel: UILabel!
     @IBOutlet var numSongsLabel: UILabel!
@@ -68,11 +69,6 @@ class QueueViewController: UIViewController, SegmentedJointDelegate, SongTableDe
             
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        
-        if (UIApplication.shared.delegate as! AppDelegate).token == "" {
-            searchIconImageView.isUserInteractionEnabled = false
-        }
-        
         watchLocationDoc()
         setupSongTableView()
     }

--- a/CranberryQueue/Queue/QueueViewController.swift
+++ b/CranberryQueue/Queue/QueueViewController.swift
@@ -123,9 +123,9 @@ class QueueViewController: UIViewController, SegmentedJointDelegate, SongTableDe
         globeIcon.addGestureRecognizer(globeTapGesture)
         globeIcon.isUserInteractionEnabled = true
         
-        let searchTap = UITapGestureRecognizer(target: self, action: #selector(self.searchTapped))
-        searchIconImageView.addGestureRecognizer(searchTap)
-        searchIconImageView.isUserInteractionEnabled = true
+        let plusTap = UITapGestureRecognizer(target: self, action: #selector(self.plusTapped))
+        plusIconImageView.addGestureRecognizer(plusTap)
+        plusIconImageView.isUserInteractionEnabled = true
         
         let leaveQueueTap = UITapGestureRecognizer(target: self, action: #selector(self.leaveQueueTapped))
         leaveQueueImageView.addGestureRecognizer(leaveQueueTap)
@@ -213,17 +213,35 @@ class QueueViewController: UIViewController, SegmentedJointDelegate, SongTableDe
         }
     }
     
-    @objc func searchTapped() {
-        queueSegmentedDelegate?.searchTapped(shouldHideContents: !segmentedContainerView.isHidden)
-        if(segmentedContainerView.isHidden) {
-            searchIconImageView.image = UIImage(named: "xIcon")!
-            presentSegmentedContainerViewAnimation()
+    @objc func plusTapped() {
+        if (UIApplication.shared.delegate as? AppDelegate)?.token == "" {
+            let alert = UIAlertController(title: "Open Spotify?", message: "Login to Spotify to Contribute", preferredStyle: .alert)
+                   alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: { action in
+                    
+                   }))
+                   alert.addAction(UIAlertAction(title: "Open Spotify", style: .default, handler: { action in
+                       /// start app remote again on retry
+                       self.startSession()
+                   }))
+                   self.present(alert, animated: true)
         } else {
-            if #available(iOS 13.0, *) {
-                searchIconImageView.image = UIImage(systemName: "plus")!
+            queueSegmentedDelegate?.searchTapped(shouldHideContents: !segmentedContainerView.isHidden)
+            if(segmentedContainerView.isHidden) {
+                plusIconImageView.image = UIImage(named: "xIcon")!
+                presentSegmentedContainerViewAnimation()
+            } else {
+                if #available(iOS 13.0, *) {
+                    plusIconImageView.image = UIImage(systemName: "plus")!
+                }
+                dismissSegmentedContainerViewAnimation()
             }
-            dismissSegmentedContainerViewAnimation()
         }
+    }
+    
+    // start session
+    func startSession() {
+        let delegate = UIApplication.shared.delegate as! AppDelegate
+        delegate.startSession()
     }
     
     func addSongTapped(song: Song) {
@@ -232,7 +250,7 @@ class QueueViewController: UIViewController, SegmentedJointDelegate, SongTableDe
         self.nextUpLabel.isHidden = false
         self.songTableView.isHidden = false
         if #available(iOS 13.0, *) {
-            searchIconImageView.image = UIImage(systemName: "plus")!
+            plusIconImageView.image = UIImage(systemName: "plus")!
         }
         dismissSegmentedContainerViewAnimation()
     }


### PR DESCRIPTION
- New login lifecycle:
    + Spotify is prompted to open when users tries to create a queue.
    + Retry app remote failure fixed
    + Guests of Queue are asked to log into spotify when they click the plus button on the segmented Controller.
    + Music is not played for the host of a queue until they actually create it.
    + Music is never played for guests of queue